### PR TITLE
Add FFI-based gRPC server example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+ffi_grpc_server/*.o
+ffi_grpc_server/libgrpcwrap.so

--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # ubiquitous-journey
 Testing ChatGPT Codex connector with GitHub
+
+## Perl OTLP gRPC Server Example
+
+This repository now includes a basic example of using Perl to receive
+OpenTelemetry Protocol (OTLP) messages over gRPC with TLS. Because the
+`Grpc::XS` module is no longer actively maintained, a minimal FFI binding to
+the gRPC C library is provided instead. The binding is implemented in
+`ffi_grpc_server/` and loaded using `FFI::Platypus`.
+
+### Files
+
+- `otel_grpc_server/otel_grpc_server.pl` – legacy example using `Grpc::XS`.
+- `ffi_grpc_server.pl` – example using the FFI binding.
+- `ffi_grpc_server/` – C wrapper and build instructions.
+- `otel_grpc_server/*.proto` – required protobuf definitions.
+
+### Running the example
+
+1. Install the required packages and Perl modules:
+
+   ```shell
+   sudo apt-get install libgrpc-dev libffi-platypus-perl
+   cpan Google::ProtocolBuffers::Dynamic
+   ```
+
+2. Build the FFI wrapper:
+
+   ```shell
+   (cd ffi_grpc_server && make)
+   ```
+
+3. Create `server.crt` and `server.key` files for TLS and place them in the
+   repository root.
+
+4. Run the FFI-based server:
+
+   ```shell
+   perl ffi_grpc_server.pl
+   ```
+
+The server listens on port `4317` (the default OTLP gRPC port). The example
+implementation currently only starts the server and does not yet decode
+messages. It demonstrates how to bind to the gRPC C library without relying
+on the unmaintained `Grpc::XS` module.

--- a/ffi_grpc_server.pl
+++ b/ffi_grpc_server.pl
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+use FFI::Platypus 1.00;
+use FFI::Platypus::Memory qw( free );
+
+my $ffi = FFI::Platypus->new( api => 1 );
+$ffi->lib('./ffi_grpc_server/libgrpcwrap.so');
+
+$ffi->type('opaque' => 'server');
+
+$ffi->attach( otel_server_new => ['string','string','string'] => 'server' );
+$ffi->attach( otel_server_destroy => ['server'] );
+
+# create server with cert/key
+my $cert = do {
+  open my $fh, '<', 'server.crt' or die "server.crt: $!";
+  local $/;
+  <$fh>;
+};
+my $key = do {
+  open my $fh, '<', 'server.key' or die "server.key: $!";
+  local $/;
+  <$fh>;
+};
+
+my $server = otel_server_new('0.0.0.0:4317',$cert,$key);
+print "Started FFI gRPC server on 0.0.0.0:4317\n";
+
+END {
+  otel_server_destroy($server) if $server;
+}
+
+sleep while 1;

--- a/ffi_grpc_server/Makefile
+++ b/ffi_grpc_server/Makefile
@@ -1,0 +1,13 @@
+all: libgrpcwrap.so
+
+libgrpcwrap.so: grpc_server_wrapper.o
+	gcc -shared -o libgrpcwrap.so grpc_server_wrapper.o \
+		-l:libgrpc++.so.1.51 -l:libgrpc++_reflection.so.1.51 \
+		-lgrpc -labsl_synchronization -labsl_str_format_internal -labsl_base \
+		-lssl -lcrypto -lpthread
+
+grpc_server_wrapper.o: grpc_server_wrapper.c
+	gcc -fPIC -c grpc_server_wrapper.c
+
+clean:
+	rm -f *.o libgrpcwrap.so

--- a/ffi_grpc_server/README.md
+++ b/ffi_grpc_server/README.md
@@ -1,0 +1,13 @@
+# FFI gRPC Server Wrapper
+
+This directory contains a very small C wrapper around the gRPC C library. It exposes
+functions for creating and destroying a gRPC server. The implementation is not complete
+but demonstrates how one could bind to the gRPC core library from Perl using `FFI::Platypus`.
+
+To build the shared library:
+
+```sh
+make
+```
+
+This requires the `libgrpc-dev` package to be installed.

--- a/ffi_grpc_server/grpc_server_wrapper.c
+++ b/ffi_grpc_server/grpc_server_wrapper.c
@@ -1,0 +1,41 @@
+#include <grpc/grpc.h>
+#include <grpc/grpc_security.h>
+#include <grpc/status.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct server_ctx {
+    grpc_server *server;
+    grpc_completion_queue *cq;
+};
+
+struct server_ctx* otel_server_new(const char* address,const char* cert,const char* key){
+    grpc_init();
+    struct server_ctx *ctx = malloc(sizeof(struct server_ctx));
+    ctx->cq = grpc_completion_queue_create_for_next(NULL);
+    ctx->server = grpc_server_create(NULL, NULL);
+    grpc_server_register_completion_queue(ctx->server, ctx->cq, NULL);
+
+    grpc_ssl_pem_key_cert_pair pair = { key, cert };
+    grpc_server_credentials *creds = grpc_ssl_server_credentials_create(NULL,&pair,1,0,NULL);
+    grpc_server_add_secure_http2_port(ctx->server, address, creds);
+    grpc_server_credentials_release(creds);
+    grpc_server_start(ctx->server);
+    return ctx;
+}
+
+void otel_server_destroy(struct server_ctx* ctx){
+    if(!ctx) return;
+    grpc_server_shutdown_and_notify(ctx->server, ctx->cq, NULL);
+    grpc_completion_queue_next(ctx->cq, gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
+    grpc_server_destroy(ctx->server);
+    grpc_completion_queue_shutdown(ctx->cq);
+    grpc_completion_queue_next(ctx->cq, gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
+    grpc_completion_queue_destroy(ctx->cq);
+    free(ctx);
+    grpc_shutdown();
+}
+
+int otel_server_poll(struct server_ctx* ctx){
+    return 0;
+}

--- a/otel_grpc_server/common.proto
+++ b/otel_grpc_server/common.proto
@@ -1,0 +1,81 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.common.v1;
+
+option csharp_namespace = "OpenTelemetry.Proto.Common.V1";
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.common.v1";
+option java_outer_classname = "CommonProto";
+option go_package = "go.opentelemetry.io/proto/otlp/common/v1";
+
+// AnyValue is used to represent any type of attribute value. AnyValue may contain a
+// primitive value such as a string or integer or it may contain an arbitrary nested
+// object containing arrays, key-value lists and primitives.
+message AnyValue {
+  // The value is one of the listed fields. It is valid for all values to be unspecified
+  // in which case this AnyValue is considered to be "empty".
+  oneof value {
+    string string_value = 1;
+    bool bool_value = 2;
+    int64 int_value = 3;
+    double double_value = 4;
+    ArrayValue array_value = 5;
+    KeyValueList kvlist_value = 6;
+    bytes bytes_value = 7;
+  }
+}
+
+// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
+// since oneof in AnyValue does not allow repeated fields.
+message ArrayValue {
+  // Array of values. The array may be empty (contain 0 elements).
+  repeated AnyValue values = 1;
+}
+
+// KeyValueList is a list of KeyValue messages. We need KeyValueList as a message
+// since `oneof` in AnyValue does not allow repeated fields. Everywhere else where we need
+// a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to
+// avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
+// are semantically equivalent.
+message KeyValueList {
+  // A collection of key/value pairs of key-value pairs. The list may be empty (may
+  // contain 0 elements).
+  // The keys MUST be unique (it is not allowed to have more than one
+  // value with the same key).
+  repeated KeyValue values = 1;
+}
+
+// KeyValue is a key-value pair that is used to store Span attributes, Link
+// attributes, etc.
+message KeyValue {
+  string key = 1;
+  AnyValue value = 2;
+}
+
+// InstrumentationScope is a message representing the instrumentation scope information
+// such as the fully qualified name and version. 
+message InstrumentationScope {
+  // An empty instrumentation scope name means the name is unknown.
+  string name = 1;
+  string version = 2;
+
+  // Additional attributes that describe the scope. [Optional].
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
+  repeated KeyValue attributes = 3;
+  uint32 dropped_attributes_count = 4;
+}

--- a/otel_grpc_server/otel_grpc_server.pl
+++ b/otel_grpc_server/otel_grpc_server.pl
@@ -1,0 +1,70 @@
+use strict;
+use warnings;
+
+use Google::ProtocolBuffers::Dynamic;
+use Grpc::XS::Server;
+use Grpc::XS::ServerCredentials;
+use Grpc::Constants qw(
+    GRPC_OP_RECV_MESSAGE
+    GRPC_OP_RECV_CLOSE_ON_SERVER
+    GRPC_OP_SEND_INITIAL_METADATA
+    GRPC_OP_SEND_MESSAGE
+    GRPC_OP_SEND_STATUS_FROM_SERVER
+    GRPC_STATUS_OK
+);
+
+sub slurp {
+    my ($file) = @_;
+    open my $fh, '<', $file or die "Cannot open $file: $!";
+    local $/; return <$fh>;
+}
+
+# Load OpenTelemetry protobuf definitions
+my $pb = Google::ProtocolBuffers::Dynamic->new(ignore_unknown_fields => 1);
+$pb->load_file('trace_service.proto', { include_path => ['.'] });
+$pb->resolve_references;
+
+# TLS credentials
+my $cert = slurp('server.crt');
+my $key  = slurp('server.key');
+my $creds = Grpc::XS::ServerCredentials::createSsl(
+    pem_private_key => $key,
+    pem_cert_chain  => $cert,
+);
+
+# Create gRPC server
+my $server = Grpc::XS::Server->new();
+$server->addSecureHttp2Port('0.0.0.0:4317', $creds);
+$server->start;
+
+print "OTLP gRPC server listening on 0.0.0.0:4317\n";
+
+while (1) {
+    my $call_info = $server->requestCall;
+    my $call      = $call_info->{call};
+
+    # Receive request message
+    my $event = $call->startBatch(
+        GRPC_OP_RECV_MESSAGE()      => 1,
+        GRPC_OP_RECV_CLOSE_ON_SERVER() => 1,
+    );
+    my $payload = $event->{message};
+    my $req = $pb->decode('opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest', $payload);
+
+    my $span_sets = 0;
+    if ($req->{resource_spans}) {
+        for my $rs (@{ $req->{resource_spans} }) {
+            $span_sets += @{ $rs->{scope_spans} || [] };
+        }
+    }
+    print "Received ExportTraceServiceRequest with $span_sets span sets\n";
+
+    # Send empty response with status OK
+    my $resp_bin = $pb->encode('opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse', {});
+    $call->startBatch(
+        GRPC_OP_SEND_INITIAL_METADATA()  => {},
+        GRPC_OP_SEND_MESSAGE()           => { message => $resp_bin },
+        GRPC_OP_SEND_STATUS_FROM_SERVER() => { code => GRPC_STATUS_OK, details => '' },
+    );
+}
+

--- a/otel_grpc_server/resource.proto
+++ b/otel_grpc_server/resource.proto
@@ -1,0 +1,37 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.resource.v1;
+
+import "opentelemetry/proto/common/v1/common.proto";
+
+option csharp_namespace = "OpenTelemetry.Proto.Resource.V1";
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.resource.v1";
+option java_outer_classname = "ResourceProto";
+option go_package = "go.opentelemetry.io/proto/otlp/resource/v1";
+
+// Resource information.
+message Resource {
+  // Set of attributes that describe the resource.
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 1;
+
+  // dropped_attributes_count is the number of dropped attributes. If the value is 0, then
+  // no attributes were dropped.
+  uint32 dropped_attributes_count = 2;
+}

--- a/otel_grpc_server/trace.proto
+++ b/otel_grpc_server/trace.proto
@@ -1,0 +1,333 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.trace.v1;
+
+import "opentelemetry/proto/common/v1/common.proto";
+import "opentelemetry/proto/resource/v1/resource.proto";
+
+option csharp_namespace = "OpenTelemetry.Proto.Trace.V1";
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.trace.v1";
+option java_outer_classname = "TraceProto";
+option go_package = "go.opentelemetry.io/proto/otlp/trace/v1";
+
+// TracesData represents the traces data that can be stored in a persistent storage,
+// OR can be embedded by other protocols that transfer OTLP traces data but do
+// not implement the OTLP protocol.
+//
+// The main difference between this message and collector protocol is that
+// in this message there will not be any "control" or "metadata" specific to
+// OTLP protocol.
+//
+// When new fields are added into this message, the OTLP request MUST be updated
+// as well.
+message TracesData {
+  // An array of ResourceSpans.
+  // For data coming from a single resource this array will typically contain
+  // one element. Intermediary nodes that receive data from multiple origins
+  // typically batch the data before forwarding further and in that case this
+  // array will contain multiple elements.
+  repeated ResourceSpans resource_spans = 1;
+}
+
+// A collection of ScopeSpans from a Resource.
+message ResourceSpans {
+  reserved 1000;
+
+  // The resource for the spans in this message.
+  // If this field is not set then no resource info is known.
+  opentelemetry.proto.resource.v1.Resource resource = 1;
+
+  // A list of ScopeSpans that originate from a resource.
+  repeated ScopeSpans scope_spans = 2;
+
+  // The Schema URL, if known. This is the identifier of the Schema that the resource data
+  // is recorded in. To learn more about Schema URL see
+  // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+  // This schema_url applies to the data in the "resource" field. It does not apply
+  // to the data in the "scope_spans" field which have their own schema_url field.
+  string schema_url = 3;
+}
+
+// A collection of Spans produced by an InstrumentationScope.
+message ScopeSpans {
+  // The instrumentation scope information for the spans in this message.
+  // Semantically when InstrumentationScope isn't set, it is equivalent with
+  // an empty instrumentation scope name (unknown).
+  opentelemetry.proto.common.v1.InstrumentationScope scope = 1;
+
+  // A list of Spans that originate from an instrumentation scope.
+  repeated Span spans = 2;
+
+  // The Schema URL, if known. This is the identifier of the Schema that the span data
+  // is recorded in. To learn more about Schema URL see
+  // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+  // This schema_url applies to all spans and span events in the "spans" field.
+  string schema_url = 3;
+}
+
+// A Span represents a single operation performed by a single component of the system.
+//
+// The next available field id is 17.
+message Span {
+  // A unique identifier for a trace. All spans from the same trace share
+  // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes OR
+  // of length other than 16 bytes is considered invalid (empty string in OTLP/JSON
+  // is zero-length and thus is also invalid).
+  //
+  // This field is required.
+  bytes trace_id = 1;
+
+  // A unique identifier for a span within a trace, assigned when the span
+  // is created. The ID is an 8-byte array. An ID with all zeroes OR of length
+  // other than 8 bytes is considered invalid (empty string in OTLP/JSON
+  // is zero-length and thus is also invalid).
+  //
+  // This field is required.
+  bytes span_id = 2;
+
+  // trace_state conveys information about request position in multiple distributed tracing graphs.
+  // It is a trace_state in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
+  // See also https://github.com/w3c/distributed-tracing for more details about this field.
+  string trace_state = 3;
+
+  // The `span_id` of this span's parent span. If this is a root span, then this
+  // field must be empty. The ID is an 8-byte array.
+  bytes parent_span_id = 4;
+
+  // Flags, a bit field. 8 least significant bits are the trace
+  // flags as defined in W3C Trace Context specification. Readers
+  // MUST not assume that 24 most significant bits will be zero.
+  // To read the 8-bit W3C trace flag, use `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
+  //
+  // When creating span messages, if the message is logically forwarded from another source
+  // with an equivalent flags fields (i.e., usually another OTLP span message), the field SHOULD
+  // be copied as-is. If creating from a source that does not have an equivalent flags field
+  // (such as a runtime representation of an OpenTelemetry span), the high 24 bits MUST
+  // be set to zero.
+  //
+  // [Optional].
+  //
+  // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+  fixed32 flags = 16;
+
+  // A description of the span's operation.
+  //
+  // For example, the name can be a qualified method name or a file name
+  // and a line number where the operation is called. A best practice is to use
+  // the same display name at the same call point in an application.
+  // This makes it easier to correlate spans in different traces.
+  //
+  // This field is semantically required to be set to non-empty string.
+  // Empty value is equivalent to an unknown span name.
+  //
+  // This field is required.
+  string name = 5;
+
+  // SpanKind is the type of span. Can be used to specify additional relationships between spans
+  // in addition to a parent/child relationship.
+  enum SpanKind {
+    // Unspecified. Do NOT use as default.
+    // Implementations MAY assume SpanKind to be INTERNAL when receiving UNSPECIFIED.
+    SPAN_KIND_UNSPECIFIED = 0;
+
+    // Indicates that the span represents an internal operation within an application,
+    // as opposed to an operation happening at the boundaries. Default value.
+    SPAN_KIND_INTERNAL = 1;
+
+    // Indicates that the span covers server-side handling of an RPC or other
+    // remote network request.
+    SPAN_KIND_SERVER = 2;
+
+    // Indicates that the span describes a request to some remote service.
+    SPAN_KIND_CLIENT = 3;
+
+    // Indicates that the span describes a producer sending a message to a broker.
+    // Unlike CLIENT and SERVER, there is often no direct critical path latency relationship
+    // between producer and consumer spans. A PRODUCER span ends when the message was accepted
+    // by the broker while the logical processing of the message might span a much longer time.
+    SPAN_KIND_PRODUCER = 4;
+
+    // Indicates that the span describes consumer receiving a message from a broker.
+    // Like the PRODUCER kind, there is often no direct critical path latency relationship
+    // between producer and consumer spans.
+    SPAN_KIND_CONSUMER = 5;
+  }
+
+  // Distinguishes between spans generated in a particular context. For example,
+  // two spans with the same name may be distinguished using `CLIENT` (caller)
+  // and `SERVER` (callee) to identify queueing latency associated with the span.
+  SpanKind kind = 6;
+
+  // start_time_unix_nano is the start time of the span. On the client side, this is the time
+  // kept by the local machine where the span execution starts. On the server side, this
+  // is the time when the server's application handler starts running.
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  //
+  // This field is semantically required and it is expected that end_time >= start_time.
+  fixed64 start_time_unix_nano = 7;
+
+  // end_time_unix_nano is the end time of the span. On the client side, this is the time
+  // kept by the local machine where the span execution ends. On the server side, this
+  // is the time when the server application handler stops running.
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  //
+  // This field is semantically required and it is expected that end_time >= start_time.
+  fixed64 end_time_unix_nano = 8;
+
+  // attributes is a collection of key/value pairs. Note, global attributes
+  // like server name can be set using the resource API. Examples of attributes:
+  //
+  //     "/http/user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
+  //     "/http/server_latency": 300
+  //     "example.com/myattribute": true
+  //     "example.com/score": 10.239
+  //
+  // The OpenTelemetry API specification further restricts the allowed value types:
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 9;
+
+  // dropped_attributes_count is the number of attributes that were discarded. Attributes
+  // can be discarded because their keys are too long or because there are too many
+  // attributes. If this value is 0, then no attributes were dropped.
+  uint32 dropped_attributes_count = 10;
+
+  // Event is a time-stamped annotation of the span, consisting of user-supplied
+  // text description and key-value pairs.
+  message Event {
+    // time_unix_nano is the time the event occurred.
+    fixed64 time_unix_nano = 1;
+
+    // name of the event.
+    // This field is semantically required to be set to non-empty string.
+    string name = 2;
+
+    // attributes is a collection of attribute key/value pairs on the event.
+    // Attribute keys MUST be unique (it is not allowed to have more than one
+    // attribute with the same key).
+    repeated opentelemetry.proto.common.v1.KeyValue attributes = 3;
+
+    // dropped_attributes_count is the number of dropped attributes. If the value is 0,
+    // then no attributes were dropped.
+    uint32 dropped_attributes_count = 4;
+  }
+
+  // events is a collection of Event items.
+  repeated Event events = 11;
+
+  // dropped_events_count is the number of dropped events. If the value is 0, then no
+  // events were dropped.
+  uint32 dropped_events_count = 12;
+
+  // A pointer from the current span to another span in the same trace or in a
+  // different trace. For example, this can be used in batching operations,
+  // where a single batch handler processes multiple requests from different
+  // traces or when the handler receives a request from a different project.
+  message Link {
+    // A unique identifier of a trace that this linked span is part of. The ID is a
+    // 16-byte array.
+    bytes trace_id = 1;
+
+    // A unique identifier for the linked span. The ID is an 8-byte array.
+    bytes span_id = 2;
+
+    // The trace_state associated with the link.
+    string trace_state = 3;
+
+    // attributes is a collection of attribute key/value pairs on the link.
+    // Attribute keys MUST be unique (it is not allowed to have more than one
+    // attribute with the same key).
+    repeated opentelemetry.proto.common.v1.KeyValue attributes = 4;
+
+    // dropped_attributes_count is the number of dropped attributes. If the value is 0,
+    // then no attributes were dropped.
+    uint32 dropped_attributes_count = 5;
+
+    // Flags, a bit field. 8 least significant bits are the trace
+    // flags as defined in W3C Trace Context specification. Readers
+    // MUST not assume that 24 most significant bits will be zero.
+    // When creating new spans, the most-significant 24-bits MUST be
+    // zero.  To read the 8-bit W3C trace flag (use flags &
+    // SPAN_FLAGS_TRACE_FLAGS_MASK).  [Optional].
+    //
+    // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+    fixed32 flags = 6;
+  }
+
+  // links is a collection of Links, which are references from this span to a span
+  // in the same or different trace.
+  repeated Link links = 13;
+
+  // dropped_links_count is the number of dropped links after the maximum size was
+  // enforced. If this value is 0, then no links were dropped.
+  uint32 dropped_links_count = 14;
+
+  // An optional final status for this span. Semantically when Status isn't set, it means
+  // span's status code is unset, i.e. assume STATUS_CODE_UNSET (code = 0).
+  Status status = 15;
+}
+
+// The Status type defines a logical error model that is suitable for different
+// programming environments, including REST APIs and RPC APIs.
+message Status {
+  reserved 1;
+
+  // A developer-facing human readable error message.
+  string message = 2;
+
+  // For the semantics of status codes see
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status
+  enum StatusCode {
+    // The default status.
+    STATUS_CODE_UNSET               = 0;
+    // The Span has been validated by an Application developer or Operator to 
+    // have completed successfully.
+    STATUS_CODE_OK                  = 1;
+    // The Span contains an error.
+    STATUS_CODE_ERROR               = 2;
+  };
+
+  // The status code.
+  StatusCode code = 3;
+}
+
+// SpanFlags represents constants used to interpret the
+// Span.flags field, which is protobuf 'fixed32' type and is to
+// be used as bit-fields. Each non-zero value defined in this enum is
+// a bit-mask.  To extract the bit-field, for example, use an
+// expression like:
+//
+//   (span.flags & SPAN_FLAGS_TRACE_FLAGS_MASK)
+//
+// See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+//
+// Note that Span flags were introduced in version 1.1 of the
+// OpenTelemetry protocol.  Older Span producers do not set this
+// field, consequently consumers should not rely on the absence of a
+// particular flag bit to indicate the presence of a particular feature.
+enum SpanFlags {
+  // The zero value for the enum. Should not be used for comparisons.
+  // Instead use bitwise "and" with the appropriate mask as shown above.
+  SPAN_FLAGS_DO_NOT_USE = 0;
+
+  // Bits 0-7 are used for trace flags.
+  SPAN_FLAGS_TRACE_FLAGS_MASK = 0x000000FF;
+
+  // Bits 8-31 are reserved for future use.
+}

--- a/otel_grpc_server/trace_service.proto
+++ b/otel_grpc_server/trace_service.proto
@@ -1,0 +1,79 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.collector.trace.v1;
+
+import "opentelemetry/proto/trace/v1/trace.proto";
+
+option csharp_namespace = "OpenTelemetry.Proto.Collector.Trace.V1";
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.collector.trace.v1";
+option java_outer_classname = "TraceServiceProto";
+option go_package = "go.opentelemetry.io/proto/otlp/collector/trace/v1";
+
+// Service that can be used to push spans between one Application instrumented with
+// OpenTelemetry and a collector, or between a collector and a central collector (in this
+// case spans are sent/received to/from multiple Applications).
+service TraceService {
+  // For performance reasons, it is recommended to keep this RPC
+  // alive for the entire life of the application.
+  rpc Export(ExportTraceServiceRequest) returns (ExportTraceServiceResponse) {}
+}
+
+message ExportTraceServiceRequest {
+  // An array of ResourceSpans.
+  // For data coming from a single resource this array will typically contain one
+  // element. Intermediary nodes (such as OpenTelemetry Collector) that receive
+  // data from multiple origins typically batch the data before forwarding further and
+  // in that case this array will contain multiple elements.
+  repeated opentelemetry.proto.trace.v1.ResourceSpans resource_spans = 1;
+}
+
+message ExportTraceServiceResponse {
+  // The details of a partially successful export request.
+  //
+  // If the request is only partially accepted
+  // (i.e. when the server accepts only parts of the data and rejects the rest)
+  // the server MUST initialize the `partial_success` field and MUST
+  // set the `rejected_<signal>` with the number of items it rejected.
+  //
+  // Servers MAY also make use of the `partial_success` field to convey
+  // warnings/suggestions to senders even when the request was fully accepted.
+  // In such cases, the `rejected_<signal>` MUST have a value of `0` and
+  // the `error_message` MUST be non-empty.
+  //
+  // A `partial_success` message with an empty value (rejected_<signal> = 0 and
+  // `error_message` = "") is equivalent to it not being set/present. Senders
+  // SHOULD interpret it the same way as in the full success case.
+  ExportTracePartialSuccess partial_success = 1;
+}
+
+message ExportTracePartialSuccess {
+  // The number of rejected spans.
+  //
+  // A `rejected_<signal>` field holding a `0` value indicates that the
+  // request was fully accepted.
+  int64 rejected_spans = 1;
+
+  // A developer-facing human-readable message in English. It should be used
+  // either to explain why the server rejected parts of the data during a partial
+  // success or to convey warnings/suggestions during a full success. The message
+  // should offer guidance on how users can address such issues.
+  //
+  // error_message is an optional field. An error_message with an empty value
+  // is equivalent to it not being set.
+  string error_message = 2;
+}


### PR DESCRIPTION
## Summary
- add FFI-based gRPC server example avoiding Grpc::XS
- provide C wrapper and build instructions
- update README with new instructions

## Testing
- `perl -c ffi_grpc_server.pl`
- `(cd ffi_grpc_server && make clean && make)`

------
https://chatgpt.com/codex/tasks/task_e_6840ba7f6758832f9e6e2c704ccc7a03